### PR TITLE
Development

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Utilities for Working With the 'fireSense' Group of 'SpaDES' Modules
 Description: Utilities for working with the 'fireSense' group of 'SpaDES' modules.
 Date: 2023-10-13
-Version: 0.0.5.9052
+Version: 0.0.5.9053
 Authors@R: c(
     person("Jean", "Marchal", email = "jean.d.marchal@gmail.com",
            role = c("aut")),

--- a/R/makeLociList.R
+++ b/R/makeLociList.R
@@ -53,6 +53,11 @@ makeLociList <- function(ras, pts, idsCol = "FIRE_ID", dateCol = "YEAR", sizeCol
     "m2" = 1,
     stop("Must provide sizeColUnits either ha or m2")
   )
+  #Check if loci sizes are numeric, otherwise the rescaling fails
+  if (class(lociDF$size) != "numeric"){
+    warning(paste0("Fire sizes were classified as ", class(lociDF$size),". Converting to numeric.")) 
+    lociDF[, size := as.numeric(size)]
+  }
   set(lociDF, NULL, "size", round(lociDF$size / (prod(res(ras)) / divisor), 0))
 
   for (index in colnames(lociDF)) {

--- a/R/makeLociList.R
+++ b/R/makeLociList.R
@@ -54,8 +54,8 @@ makeLociList <- function(ras, pts, idsCol = "FIRE_ID", dateCol = "YEAR", sizeCol
     stop("Must provide sizeColUnits either ha or m2")
   )
   #Check if loci sizes are numeric, otherwise the rescaling fails
-  if (class(lociDF$size) != "numeric"){
-    warning(paste0("Fire sizes were classified as ", class(lociDF$size),". Converting to numeric.")) 
+  if (!inherits(x = lociDF$size, what = "numeric")){
+    warning(paste0("Fire sizes were classified as ", class(lociDF$size),". Converting to numeric."))
     lociDF[, size := as.numeric(size)]
   }
   set(lociDF, NULL, "size", round(lociDF$size / (prod(res(ras)) / divisor), 0))


### PR DESCRIPTION
I was hitting the following error with the previous code:
```
Error in lociDF$size/(prod(res(ras))/divisor) :
  non-numeric argument to binary operator
```
I tracked down to the column `size` of the data.table `lociDF` being character and not numeric, while used below in a mathematical division:
```
lociDF$size/(prod(res(ras))/divisor)
```
My PR made sure this column will always be numeric and will warn user about the transformation.